### PR TITLE
feat: add content-driven pages pattern and /myrrys company page

### DIFF
--- a/specs/content-pages/spec.md
+++ b/specs/content-pages/spec.md
@@ -1,0 +1,154 @@
+# Spec: Content-Driven Pages
+
+## Blueprint (Design)
+
+### Context
+
+> **Goal:** Provide a reusable pattern for content-driven informational pages where body text lives in Markdown files with frontmatter-driven theming.
+> **Why:** The footer links to `/myrrys` ("Tietoja yrityksestä") but no page exists — it's a dead link. More broadly, the site has no pattern for standalone informational pages; all current pages are pure `.astro` files with hardcoded content.
+> **Architectural Impact:** New content collection (`site-pages`), new dynamic route (`src/pages/[id].astro`), and a breadcrumb label mapping update.
+
+### Architecture
+
+A new Astro content collection named `site-pages` sources Markdown files from `src/site-pages/`. Each file's frontmatter declares `title`, optional `description`, optional `image`, and optional `theme` (matching the existing theme enum). A single-segment dynamic route at `src/pages/[id].astro` renders these pages using the same layout pattern as blog posts.
+
+```
+src/
+  site-pages/
+    myrrys.md          # First content page — company info
+  pages/
+    [id].astro         # Dynamic route for site-pages collection
+  content.config.ts    # Collection schema definition
+```
+
+**Data flow:**
+
+1. Astro content loader globs `src/site-pages/*.md`
+2. `getStaticPaths()` maps each entry to `{ params: { id }, props: { page } }`
+3. Template renders `<h1>` from frontmatter `title`, content from Markdown body
+4. `class:list` on `<main>` applies optional `theme` class alongside `content-grid`
+
+### Anti-Patterns
+
+<rules>
+<rule id="no-hardcoded-content-pages">
+NEVER create standalone `.astro` files with hardcoded content for informational pages. Use the `site-pages` collection and Markdown files instead. This keeps content editable without touching component code.
+</rule>
+<rule id="no-catch-all-route">
+NEVER use catch-all `[...id]` routes for site pages. Single-segment `[id]` is sufficient (YAGNI) and avoids accidentally shadowing nested existing routes like `/letl/srd/*`.
+</rule>
+<rule id="no-h1-in-markdown-body">
+NEVER include an H1 (`#`) in site-page Markdown body content. The `<h1>` is injected by the template from `frontmatter.title`. Body content should start at H2 (`##`).
+</rule>
+</rules>
+
+---
+
+## Contract (Quality)
+
+### Definition of Done
+
+- [ ] `site-pages` collection defined in `src/content.config.ts` with `title`, `description`, `image`, and `theme` fields.
+- [ ] Dynamic route `src/pages/[id].astro` renders collection entries with theme class support.
+- [ ] `/myrrys` page renders with company info, `theme-letl` class, and correct meta tags.
+- [ ] Breadcrumb JSON-LD shows "Myrrysmiehet Oy" for the `myrrys` segment.
+- [ ] Footer link to `/myrrys` resolves (no dead link).
+- [ ] No "undefined" string appears in class attributes when theme is omitted.
+- [ ] Logic unit tested completely using `vitest` (no arbitrary DOM checks, pure script evaluation).
+- [ ] Spec scenarios functionally verified through Playwright E2E tests (`tests/`).
+
+### Regression Guardrails
+
+<invariants>
+<invariant id="single-h1">
+Every rendered page must have exactly one `<h1>` element.
+If violated, SEO and accessibility scores degrade; the SEO sweep tests fail.
+</invariant>
+<invariant id="no-undefined-class">
+The `class` attribute on `<main>` must never contain the literal string "undefined".
+If violated, CSS theming breaks and pages render with incorrect styling.
+</invariant>
+<invariant id="footer-link-resolves">
+The footer link to `/myrrys` must return HTTP 200.
+If violated, users encounter a dead link from every page on the site.
+</invariant>
+</invariants>
+
+### Scenarios
+
+```gherkin
+Feature: Content-Driven Pages
+
+  Scenario: Myrrys page renders with correct content
+    Given the site-pages collection contains "myrrys.md"
+    When a user navigates to "/myrrys"
+    Then the page returns HTTP 200
+    And the page has exactly one H1 with text "Myrrysmiehet Oy"
+    And the main element has classes "theme-letl" and "content-grid"
+
+  Scenario: Meta tags populated from frontmatter
+    Given "myrrys.md" has title "Myrrysmiehet Oy" and a description
+    When a user navigates to "/myrrys"
+    Then the page title contains "Myrrysmiehet Oy"
+    And the meta description is populated
+
+  Scenario: Theme class omitted when not set
+    Given a site-page with no theme in frontmatter
+    When the page renders
+    Then the main element class does not contain "undefined"
+    And the main element has class "content-grid"
+
+  Scenario: Footer link resolves
+    Given the site footer contains a link to "/myrrys"
+    When a user clicks "Tietoja yrityksestä"
+    Then the browser navigates to "/myrrys"
+    And the page returns HTTP 200
+
+  Scenario: Breadcrumb shows mapped label
+    Given the breadcrumb segment labels include "myrrys" → "Myrrysmiehet Oy"
+    When a user navigates to "/myrrys"
+    Then the JSON-LD BreadcrumbList contains "Myrrysmiehet Oy"
+```
+
+---
+
+## Implementation Files
+
+| File | Responsibility |
+|------|----------------|
+| `src/content.config.ts` | Defines `site-pages` collection schema |
+| `src/site-pages/myrrys.md` | Myrrys company page content |
+| `src/pages/[id].astro` | Dynamic route rendering site-pages entries |
+| `src/components/base/BaseHead.astro` | Breadcrumb label mapping for `myrrys` segment |
+| `src/pages/content-page-theme.test.ts` | Vitest unit tests for theme class resolution |
+| `tests/content-pages.spec.ts` | Playwright E2E tests for content pages |
+| `tests/seo.spec.ts` | SEO sweep updated with `/myrrys` |
+
+---
+
+## Decision Log
+
+### Single-segment route over catch-all
+
+**Decision:** Use `[id].astro` instead of `[...id].astro`.
+
+**Reasoning:**
+1. All current site pages are single-segment paths (e.g., `/myrrys`).
+2. Catch-all routes risk shadowing existing nested routes like `/letl/srd/*`.
+3. YAGNI — if nested content pages are needed later, the route can be upgraded.
+
+**Trade-offs:**
+- Pro: Simpler, safer, no route conflicts.
+- Con: Cannot serve nested paths like `/about/team` without a separate route.
+
+### Source directory naming
+
+**Decision:** Use `src/site-pages/` instead of `src/pages/` for content files.
+
+**Reasoning:**
+1. `src/pages/` is reserved by Astro for file-based routing.
+2. `src/site-pages/` follows the existing pattern of content directories living at the `src/` level (e.g., `src/blog/`, `src/products/`).
+
+**Trade-offs:**
+- Pro: No conflict with Astro's routing conventions.
+- Con: One more top-level directory in `src/`.

--- a/src/components/base/BaseHead.astro
+++ b/src/components/base/BaseHead.astro
@@ -34,6 +34,7 @@ const segmentLabels: Record<string, string> = {
   "the-quick": "The Quick",
   en: "English",
   tag: "Tagi",
+  myrrys: "Myrrysmiehet Oy",
 };
 
 function formatSegment(segment: string): string {

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -44,6 +44,19 @@ const productsEn = defineCollection({
   schema: productSchema,
 });
 
+const pageSchema = ({ image }: SchemaContext) =>
+  z.object({
+    title: z.string(),
+    description: z.string().optional(),
+    image: image().optional(),
+    theme: z.enum(["theme-letl", "theme-quick", "theme-legenda"]).optional(),
+  });
+
+const sitePages = defineCollection({
+  loader: glob({ pattern: ["*.md"], base: "src/site-pages" }),
+  schema: pageSchema,
+});
+
 const lnlsrd = defineCollection({
   loader: glob({ pattern: ["**/*.md"], base: "LnL-SRD" }),
   schema: z.object({}),
@@ -55,4 +68,5 @@ export const collections = {
   lnlsrd,
   "blog-en": blogEn,
   "products-en": productsEn,
+  "site-pages": sitePages,
 };

--- a/src/pages/[id].astro
+++ b/src/pages/[id].astro
@@ -1,0 +1,30 @@
+---
+import { getCollection, render } from "astro:content";
+import Page from "@layouts/Page.astro";
+
+export async function getStaticPaths() {
+  const pages = await getCollection("site-pages");
+  return pages.map((page) => ({
+    params: { id: page.id },
+    props: { page },
+  }));
+}
+
+const { page } = Astro.props;
+const { Content } = await render(page);
+---
+
+<Page
+  title={page.data.title}
+  description={page.data.description}
+  image={page.data.image?.src}
+>
+  <main class:list={[page.data.theme, "content-grid"]}>
+    <section>
+      <article>
+        <h1>{page.data.title}</h1>
+        <Content />
+      </article>
+    </section>
+  </main>
+</Page>

--- a/src/pages/blog/[id].astro
+++ b/src/pages/blog/[id].astro
@@ -64,6 +64,7 @@ if (post.data.author) {
     object-fit: contain;
     object-position: center;
     width: 100%;
+    height: auto;
     margin-bottom: calc(var(--grid) * 2);
   }
 </style>

--- a/src/pages/content-page-theme.test.ts
+++ b/src/pages/content-page-theme.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+// Replicate the relevant class:list logic from src/pages/[id].astro
+// This mimics how Astro's class:list directive filters out falsy values like undefined, null, and false.
+function resolveClassList(
+  items: (string | undefined | null | false)[],
+): string {
+  return items.filter(Boolean).join(" ");
+}
+
+describe("Content Page Theme Logic", () => {
+  it("resolves to both theme and content-grid class when theme is defined", () => {
+    const theme = "theme-letl";
+    const result = resolveClassList([theme, "content-grid"]);
+
+    expect(result).toBe("theme-letl content-grid");
+    expect(result).toContain("theme-letl");
+    expect(result).toContain("content-grid");
+  });
+
+  it("safely filters out undefined theme preventing 'undefined content-grid' bug", () => {
+    const theme = undefined;
+    const result = resolveClassList([theme, "content-grid"]);
+
+    expect(result).toBe("content-grid");
+    expect(result).not.toContain("undefined");
+  });
+
+  it("safely filters out null theme", () => {
+    const theme = null;
+    const result = resolveClassList([theme, "content-grid"]);
+
+    expect(result).toBe("content-grid");
+    expect(result).not.toContain("null");
+  });
+});

--- a/src/site-pages/myrrys.md
+++ b/src/site-pages/myrrys.md
@@ -1,0 +1,32 @@
+---
+title: "Myrrysmiehet Oy"
+description: "Myrrysmiehet Oy on 2009 perustettu roolipeleihin keskittyvä kustannusosakeyhtiö."
+theme: theme-letl
+---
+
+Myrrysmiehet Oy on 2009 perustettu roolipeleihin keskittyvä kustannusosakeyhtiö. Yhtiö perustettiin alunperin tukemaan pien- ja omakustanteita ja näiden talous- ja verohallintoa. Nykyisin yritys keskittyy toiminnassaan Legendoja ja Lohikäärmeitä -pelin tuottamiseen, tukemiseen ja markkinointiin - mutta olemme avoimia yhteistyölle ja kustannustoiminnalle myös muiden pelien osalta.
+
+Yrityksellä ei ole yhtään varsinaista työntekijää, ja sen tuotto pyritään ohjaamaan pelien kehittämiseen ja julkaisemiseen.
+
+## Voisiko Myrrysmiehet kustantaa pelini?
+
+**Miksipä ei!**
+
+Käytännössä tähän liittyy kuitenkin muutama seikka, joista on hyvä olla tietoinen.
+
+1. Myrrysmiehet ei tuota tai kehitä pelejä. Jos siis tarvitset apua pelin saamisessa valmiiksi - tarvitset tukea joko toisilta pelien tekijöiltä tai joltain pelistudiolta. Autamme mielellämme julkaisuanne löytämään oikean yhteistyötahon.
+2. Myrrysmiehet ei rahoita pelien julkaisua tai markkinointia L&L:ää lukuunottamatta. Tämä tarkoittaa sitä, että julkaisun on oltava tarvepainettu tai että julkaisulle löytyy ulkoinen rahoitus. Autamme mielellämme tässäkin asiassa.
+
+Jos ylläolevat seikat saadaan ratkaistua - on hyvin todennäköistä että Myrrysmiehet voi toimia pelisi kustantajana.
+
+### Miksi käyttää kustannusyritystä?
+
+Julkaisuun liittyy lähes aina jonkin verran hallintoa ja rahaliikennettä, jotka on helpointa tehdä yrityksen kautta. Tällöin yritys vastaa palkkioiden verotuksesta, mahdollista työnantajamaksuista, alveista ja muista veroista. Jossain tapauksissa myös painotalojen ja muiden toimijoiden työskentely on helpompaa yrityksen kautta.
+
+Myös toiminimen tai yhdistyksen kannalta, voi olla helpompaa ja yksinkertaisempaa käyttää ulkoista kustantajaa, joka voi hallinnoida ja tilittää hankkeen menot ja tulot erikseen.
+
+## Pelien jakelu
+
+*Jos olet kiinnostunut vähittäismyymään tai jakelemaan Myrrysmiesten pelejä - ota yhteyttä. Mieluusti toimitamme pelejä myyntivarastoosi.*
+
+Muutoin Myrrysmiesten jakelu tapahtuu vapaaehtoisten pyörittämien myyntipöytien kautta Coneissa.

--- a/tests/content-pages.spec.ts
+++ b/tests/content-pages.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Feature: Content-Driven Pages", () => {
+  test("Scenario: /myrrys returns HTTP 200", async ({ page }) => {
+    const response = await page.goto("/myrrys");
+    expect(response?.status()).toBe(200);
+  });
+
+  test("Scenario: Myrrys page has exactly one H1 with correct text", async ({
+    page,
+  }) => {
+    await page.goto("/myrrys");
+    const h1 = page.locator("h1");
+    await expect(h1).toHaveCount(1);
+    await expect(h1).toHaveText("Myrrysmiehet Oy");
+  });
+
+  test("Scenario: <main> has theme-letl and content-grid classes", async ({
+    page,
+  }) => {
+    await page.goto("/myrrys");
+    const main = page.locator("main").first();
+    await expect(main).toHaveClass(/theme-letl/);
+    await expect(main).toHaveClass(/content-grid/);
+  });
+
+  test("Scenario: Title and description meta populated from frontmatter", async ({
+    page,
+  }) => {
+    await page.goto("/myrrys");
+    const title = await page.title();
+    expect(title).toContain("Myrrysmiehet Oy");
+
+    const description = await page
+      .locator('meta[name="description"]')
+      .getAttribute("content");
+    expect(description).toBeTruthy();
+    expect(description).toContain("kustannusosakeyhtiö");
+  });
+
+  test("Scenario: No 'undefined' in class attribute", async ({ page }) => {
+    await page.goto("/myrrys");
+    const mainClass = await page.locator("main").first().getAttribute("class");
+    expect(mainClass).not.toContain("undefined");
+  });
+
+  test("Scenario: Footer link to /myrrys resolves", async ({ page }) => {
+    await page.goto("/");
+    const footerLink = page.locator('footer a[href="/myrrys"]');
+    await expect(footerLink).toBeVisible();
+    await footerLink.click();
+    await page.waitForURL("**/myrrys");
+    const h1 = page.locator("h1");
+    await expect(h1).toHaveText("Myrrysmiehet Oy");
+  });
+
+  test("Scenario: Breadcrumb JSON-LD contains mapped label", async ({
+    page,
+  }) => {
+    await page.goto("/myrrys");
+    const schemas = await page.evaluate(() => {
+      const scripts = document.querySelectorAll(
+        'script[type="application/ld+json"]',
+      );
+      return Array.from(scripts).map((s) => JSON.parse(s.textContent ?? "{}"));
+    });
+    const bc = schemas.find((s) => s["@type"] === "BreadcrumbList");
+    expect(bc).toBeDefined();
+    expect(bc.itemListElement).toHaveLength(2);
+    expect(bc.itemListElement[1].name).toBe("Myrrysmiehet Oy");
+  });
+});

--- a/tests/seo.spec.ts
+++ b/tests/seo.spec.ts
@@ -225,6 +225,7 @@ const seoSweepPages = [
   "/letl/srd/readme",
   "/en/blog",
   "/legenda",
+  "/myrrys",
 ];
 
 test.describe("SEO Verification Sweep", () => {


### PR DESCRIPTION
Introduce a reusable site-pages content collection for markdown-driven informational pages with frontmatter theming. Implement /myrrys as the first page, resolving the dead footer link to "Tietoja yrityksestä".